### PR TITLE
Improve CloseableLockTest

### DIFF
--- a/src/test/java/test/com/csitte/autocloseablelock/CloseableLockTest.java
+++ b/src/test/java/test/com/csitte/autocloseablelock/CloseableLockTest.java
@@ -54,8 +54,7 @@ public class CloseableLockTest
             }
         });
         thread.start();
-        Thread.sleep(100);
-        assertTrue(locked.get()); // "Lock acquired"
+        assertTrue(lock.waitForCondition(locked::get, SEC2));
 
         thread.join();
     }
@@ -78,8 +77,7 @@ public class CloseableLockTest
         });
 
         thread.start();
-        Thread.sleep(100);
-        assertTrue(locked.get()); // false: lock not acquired
+        assertTrue(lock.waitForCondition(locked::get, SEC2));
 
         thread.join();
     }
@@ -102,10 +100,10 @@ public class CloseableLockTest
             }
         });
         thread.start();
-        Thread.sleep(100);
+        assertTrue(lock.waitForCondition(locked::get, SEC2));
         thread.interrupt();
         thread.join();
-        assertTrue(locked.get());   // false: lock not acquired
+        assertTrue(locked.get());   // "Lock acquired"
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Summary
- make unit tests wait for lock state without `Thread.sleep`

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68453e6cc0288325a69bae58729ae1cf