### PR TITLE
Fix Javadoc formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.settings/
 /.classpath
 /.project
+/.pmd
 /target/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # AutoCloseable Lock
 
-This package provides a simple wrapper for the [`java.util.concurrent.locks`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/locks/package-summary.html) package
-which can be used with the Java try-with-resources functionality.</br>
-It also handles any `InterruptedException` during waits
-and also handles timeouts correctly,
-when '[spurious](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/locks/Condition.html)'-wakeups occur.
+The AutoCloseableLock package provides a convenient and reliable way to use locks in Java.
+The try-with-resources feature, handling of exceptions and timeouts,
+and the possibility of waiting for conditions make this package an attractive choice for multi-threaded applications.
+With the additional functionality provided by CloseableReadWriteLock and LockCondition,
+developers can easily implement robust synchronization mechanisms in their applications.
+
+This package provides a simple wrapper for the [`java.util.concurrent.locks`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/locks/package-summary.html) package, which can be used with Java's try-with-resources functionality. </br>
+It also handles any `InterruptedException` during waits and correctly manages timeouts when "[spurious](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/locks/Condition.html)"-wakeups occur.
+
 
 Add the following to the `<dependencies/>` section of your pom.xml -
 
@@ -32,13 +36,13 @@ Instead of the traditional way:
             }
             finally
             {
-                myLock.close();
+                myLock.unlock();
             }
         }
         
 Use it with the try-with-resources feature:
 
-        CloseableLock myLock = new CloseableLock();
+        CloseableLock myLock = new CloseableLock(new ReentrantLock());
         void method()
         {
             try (AutoCloseableLock autoCloseableLock = myLock.lock())
@@ -47,7 +51,9 @@ Use it with the try-with-resources feature:
             }
         }
         
-When the scope is left, it is ensured that the lock will be released.
+The `CloseableLock` class provides a wrapper for a `java.util.concurrent.locks.Lock` object.
+By default, a `ReentrantLock` is used, but any other `Lock`-implementation can be provided in the constructor.
+When the scope is exited, it is ensured that the lock will be released.
         
 ## Try lock with timeout
 
@@ -62,17 +68,17 @@ When the scope is left, it is ensured that the lock will be released.
             // do appropriate error handling
         }
 
-If the lock cannot be aquired before the timeout duration expires, than a `LockTimeoutException` is thrown.
+If the lock cannot be acquired before the timeout duration expires, then a `LockTimeoutException` is thrown.
 
 ## Wait
 
-The `wait()`-Method does what it's name says: waiting for the specified time.
+The `wait()` method does what its name says: it waits for the specified time.
 
         new CloseableLock().wait(Duration.ofSeconds(10));
         
 ## Wait for condition
 
-You can use a `BooleanSupplier` as an argument to test if a condition is true, until the given timeout expires.
+You can use a `BooleanSupplier` as an argument to test if a condition is true until the given timeout expires.
 
         CloseableLock myLock = new CloseableLock();
         if (myLock.waitForCondition(()->isReady(), Duration.ofSeconds(10))
@@ -84,18 +90,18 @@ You can use a `BooleanSupplier` as an argument to test if a condition is true, u
             # condition is not ready after 10 seconds. Do error handling...
         }
             
-A timeout value of zero means, that the method only returns when the condition is true.
-Any other thread can use the `CloseableLock.signalAll()` method to signal waiting threads a change in condition.
-Otherwise the test is performed in one-second intervals.
+A timeout value of zero means that the method only returns when the condition is true.
+Any other thread can use the `CloseableLock.signalAll()` method to signal waiting threads of a change in condition.
+Otherwise, the test is performed at one-second intervals.
 
 ## ReadWriteLock
 
-Use `CloseableReadWriteLock` if you need the [`ReadWriteLock`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/locks/ReadWriteLock.html)
-functionality and also want the `AutoCloseable` benefits.
-The read lock may be simultaneously held by multiple threads as long as there is no write.
-One speciality here is the possibility to downgrade a write-lock to a read-lock without losing the grip on the lock.
+Use `CloseableReadWriteLock` if you need the [`ReadWriteLock`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/locks/ReadWriteLock.html) 
+functionality and also want the benefits of `AutoCloseable`.
+The read-lock may be held simultaneously by multiple threads as long as there is no write-lock.
+A unique feature is the ability to downgrade a write-lock to a read-lock without losing the hold on the lock.
 
-        CloseableReadWriteLock readWriteLock = new CloseableReadWriteLock();
+        CloseableReadWriteLock readWriteLock = new CloseableReadWriteLock(new ReentrantReadWriteLock());
         void method()
         {
             try (AutoCloseableWriteLock acwl = readWriteLock.writeLock())
@@ -111,23 +117,36 @@ One speciality here is the possibility to downgrade a write-lock to a read-lock 
 The `CloseableReadWriteLock` has the following locking-methods:
 
             AutoCloseableWriteLock writeLock()
+            AutoCloseableWriteLock writeLockInterruptibly()
             AutoCloseableWriteLock tryWriteLock(Duration)
             AutoCloseableLock readLock()
             AutoCloseableLock tryReadLock(Duration)
-            void downgradeToReadLock()
+
+The methods that acquire a write-lock return an `AutoCloseableWriteLock` object,
+which should be used in a try-with-resources block to ensure that the lock is released afterwards.
+Inside the block, the following methods can be used with `AutoCloseableWriteLock`.
+
+             void wait(Duration timeout)
+             boolean waitForCondition(BooleanSupplier fCondition, Duration timeout)
+             void signalAll()
+             void signal()
+             void downgradeToReadLock()
+             void downgradeToReadLockInterruptibly()
             
 ## LockCondition
 
-This class represents a state. It is bound to a lock. If the state of the `LockCondition` changes,
-this is signalled to all waiting threads. The setState()-method aquires the lock before changing the state.
+This class represents a state. It is bound to a lock. If the state of the `LockCondition` changes, 
+this is signaled to all waiting threads. The `setState()` method acquires the lock before changing the state.
 
+        # Example
+        enum STATE { INIT, ACTIVE, FINISHED }
         CloseableLock myLock = new CloseableLock();
         LockCondition<State> state = new LockCondition<>(myLock, State.INIT);
-
+        
         void doActivity()
         {
             state.setState(State.ACTIVE);
-            doSomethine();
+            doSomething();
             state.setState(State.FINISHED);
         }
         
@@ -135,17 +154,34 @@ this is signalled to all waiting threads. The setState()-method aquires the lock
         {
             myLock.waitForCondition(()->state.getState()==State.FINISHED, timeout);    
         }
+
+
+        # This is another example using a 'String' as state-variable.
+        CloseableLock myLock = new CloseableLock();
+        LockCondition<String> condition = new LockCondition<>(myLock, "Init");
+        
+        void doActivity()
+        {
+            state.setState("Active");
+            doSomething();
+            state.setState("Finished");
+        }
+        
+        void waitUntilActivityHasFinished()
+        {
+            myLock.waitForCondition(()->state.getState().equals("Finished"), timeout);    
+        }
         
 ## BooleanLockCondition
 
-This is a convenience class for `LockCondition<Boolean>`. It has the initial default value of FALSE.
+This is a convenience class for `LockCondition<Boolean>`. It has an initial default value of `FALSE`.
 
         CloseableLock myLock = new CloseableLock();
-        BooleanLockCondition finished = new BooleanLockCondition<>(myLock);
+        BooleanLockCondition finished = new BooleanLockCondition(myLock);
 
         void doActivity()
         {
-            doSomethine();
+            doSomething();
             finished.setState(true);
         }
         

--- a/pom.xml
+++ b/pom.xml
@@ -44,11 +44,43 @@
       <id>release</id>
       <build>
         <plugins>
-        
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.5.0</version>
+            <executions>
+              <execution>
+                <id>enforce-maven</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireMavenVersion>
+                      <version>3.6.3</version>
+                    </requireMavenVersion>
+                  </rules>    
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+     
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.14.0</version>
+            <configuration>
+                <source>${maven.compiler.source}</source>
+                <target>${maven.compiler.target}</target>
+                <release>${maven.compiler.release}</release>
+            </configuration>
+          </plugin>
+                    
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -69,7 +101,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
+            <version>1.7.0</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>
@@ -95,7 +127,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.3.0</version>
+            <version>3.11.2</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -106,12 +138,54 @@
             </executions>
           </plugin>
           
+          <!-- PMD Plugin -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-pmd-plugin</artifactId>
+            <version>3.26.0</version>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>check</goal>
+                        <goal>cpd-check</goal>
+                    </goals>
+                    <configuration>
+                        <excludeFromFailureFile>exclude-pmd.properties</excludeFromFailureFile>
+                    </configuration>
+                </execution>              
+            </executions>
+            <configuration>
+                <targetJdk>1.8</targetJdk>
+            </configuration>
+          </plugin>
+          
+          <!-- 
+              mvn versions:display-dependency-updates
+              mvn versions:display-plugin-updates
+              mvn versions:display-property-updates 
+          -->
+          <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>versions-maven-plugin</artifactId>
+              <version>2.18.0</version>
+          </plugin>          
+          
         </plugins>
       </build>
       
+      <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.26.0</version>
+            </plugin>
+        </plugins>
+      </reporting>
+    
       <distributionManagement>
         <snapshotRepository>
-          <id>ossrh</id>
+          <id>snapshots</id>
           <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
@@ -125,12 +199,13 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>        
+    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>        
+    <maven.compiler.release>8</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <log4j.version>2.19.0</log4j.version>
-    <junit.jupiter.version>5.9.1</junit.jupiter.version>
+    <log4j.version>2.23.1</log4j.version>
+    <junit.jupiter.version>5.13.1</junit.jupiter.version>
   </properties>
   
   <dependencies>

--- a/src/main/java/com/csitte/activity/Activity.java
+++ b/src/main/java/com/csitte/activity/Activity.java
@@ -2,143 +2,47 @@ package com.csitte.activity;
 
 import java.time.Instant;
 
-import com.csitte.autocloseablelock.AutoCloseableLock;
 import com.csitte.autocloseablelock.CloseableLock;
 import com.csitte.autocloseablelock.LockCondition;
 
 
 /**
- *	Represents an activity which has a start, some sort of activity and an end.
- *	Use the lock() method to access the resources of an activity.
- *  Use the waitForCondition() method to synchronize with any activity condition.
+ *	Represents an activity which has a start,
+ *  some sort of activity with optional states and an end.
+ *	Use the getLock() method to access the activity lock.
+ *  Use the getCondition() method to synchronize with any activity condition.
  */
-public class Activity<T>
+public interface Activity<T>
 {
-    //- Activity timestamps
-    private Instant startOfActivity;
-    private Instant lastActivity = Instant.EPOCH;
-    private Instant endOfActivity;
-    private LockCondition<T> condition;
-    private final CloseableLock activityLock = new CloseableLock();
+    /** @return  activity-lock */
+    CloseableLock getLock();
 
+    /** @return activity-condition */
+    LockCondition<T> getCondition();
 
-    public CloseableLock getLock()
-    {
-        return activityLock;
-    }
+    /** @return is activity active? */
+    boolean isActive();
 
-    protected LockCondition<T> getCondition()
-    {
-        if (condition == null)
-        {
-            try (AutoCloseableLock lock = activityLock.lock())
-            {
-                if (condition == null)
-                {
-                    condition = new LockCondition<>(activityLock, null);
-                }
-            }
-        }
-        return condition;
-    }
+    /** @return start-of-activity timestamp */
+    Instant getStartOfActivity();
 
+    /** @return timestamp of last activity */
+    Instant getLastActivity();
 
-    public boolean isActive()
-    {
-        try (AutoCloseableLock lock = activityLock.lock())
-        {
-            return startOfActivity != null && endOfActivity == null;
-        }
-    }
+    /** @return end-of-activity timestamp. null == unknown */
+    Instant getEndOfActivity();
 
-    public Instant getStartOfActivity()
-    {
-        return startOfActivity;
-    }
+    /** Update activity-status condition */
+    void updateStatus(T status);
 
-    public Instant getLastActivity()
-    {
-        return lastActivity;
-    }
+    /** @return activity-status condition */
+    T getStatus();
 
-    public Instant getEndOfActivity()
-    {
-        return endOfActivity;
-    }
-
-    public void updateStatus(T status)
-    {
-        try (AutoCloseableLock lock = activityLock.lock())
-        {
-            getCondition().setState(status);
-            lastActivity = Instant.now();
-        }
-    }
-
-    public T getStatus()
-    {
-        return getCondition().getState();
-	}
-
-    /**
-     *	Start activity.
-     *
-     *  @return AutoCloseable object for try-with-resources functionality
-     */
-    public CloseableActivity startActivity()
-    {
-        try (AutoCloseableLock lock = activityLock.lock())
-        {
-            if (isActive())
-            {
-                throw new ActivityRuntimeException("already active");
-            }
-            //- setup timestamps
-            startOfActivity = Instant.now();
-            lastActivity = startOfActivity;
-            endOfActivity = null;
-            return this::close;
-        }
-    }
-
-    public Instant touch()
-    {
-        try (AutoCloseableLock lock = activityLock.lock())
-        {
-            if (!isActive())
-            {
-                throw new ActivityRuntimeException("not active");
-            }
-            lastActivity = Instant.now();
-            return lastActivity;
-        }
-    }
+    /** Update last-activity timestamp */
+    Instant touch();
 
     /**
      *	Close this activity
      */
-    public void close()
-    {
-        try (AutoCloseableLock autoCloseableLock = activityLock.lock())
-        {
-            if (!isActive())
-            {
-                throw new ActivityRuntimeException("not active");
-            }
-            lastActivity = Instant.now();
-            endOfActivity = lastActivity;
-        }
-    }
-
-    @Override
-    public String toString()
-    {
-        try (AutoCloseableLock lock = activityLock.lock())
-        {
-            return " startOfActivity=" + startOfActivity
-            	 + " lastActivity="    + lastActivity
-            	 + " endOfActivity="   + endOfActivity
-            	 + " status="          + condition;
-        }
-    }
+    void close();
 }

--- a/src/main/java/com/csitte/activity/ActivityImpl.java
+++ b/src/main/java/com/csitte/activity/ActivityImpl.java
@@ -1,0 +1,180 @@
+package com.csitte.activity;
+
+import java.time.Instant;
+
+import com.csitte.autocloseablelock.AutoCloseableLock;
+import com.csitte.autocloseablelock.CloseableLock;
+import com.csitte.autocloseablelock.LockCondition;
+
+
+/**
+ *	Represents an activity which has a start, some sort of activity and an end.
+ *	Use the lock() method to access the resources of an activity.
+ *  Use the waitForCondition() method to synchronize with any activity condition.
+ */
+@SuppressWarnings("PMD.AtLeastOneConstructor")
+public class ActivityImpl<T> implements Activity<T>
+{
+    //- Activity timestamps
+
+    /** Start-Of-Activity timestamp */
+    private Instant startOfActivity = Instant.EPOCH; // '1970' (no activity)
+
+    /** Timestamp of last activity */
+    private Instant lastActivity = Instant.EPOCH; // '1970' (unknown)
+
+    /** End-Of-Activity Timestamp */
+    private Instant endOfActivity = Instant.MAX; // unknown end
+
+    /** Activity-Condition */
+    private LockCondition<T> condition;
+
+    /** Lock to support multi-threaded access */
+    private final CloseableLock activityLock = new CloseableLock();
+
+
+    /** @return  activity-lock */
+    @Override
+    public CloseableLock getLock()
+    {
+        return activityLock;
+    }
+
+    /** @return activity-condition */
+    @Override
+    public LockCondition<T> getCondition()
+    {
+        if (condition == null)
+        {
+            try (AutoCloseableLock lock = activityLock.lock())
+            {
+                assert lock != null; // ignored on runtime
+                if (condition == null)
+                {
+                    condition = new LockCondition<>(activityLock, null);
+                }
+            }
+        }
+        return condition;
+    }
+
+    /** @return is activity active? */
+    @Override
+    public boolean isActive()
+    {
+        try (AutoCloseableLock lock = activityLock.lock())
+        {
+            assert lock != null; // ignored on runtime
+            return startOfActivity != Instant.EPOCH && endOfActivity == Instant.MAX;
+        }
+    }
+
+    /** @return start-of-activity timestamp */
+    @Override
+    public Instant getStartOfActivity()
+    {
+        return startOfActivity == Instant.EPOCH? null: startOfActivity;
+    }
+
+    /** @return timestamp of last activity */
+    @Override
+    public Instant getLastActivity()
+    {
+        return lastActivity;
+    }
+
+    /** @return end-of-activity timestamp. null == unknown */
+    @Override
+    public Instant getEndOfActivity()
+    {
+        return endOfActivity==Instant.MAX? null: endOfActivity;
+    }
+
+    /** Update activity-status condition */
+    @Override
+    public void updateStatus(final T status)
+    {
+        try (AutoCloseableLock lock = activityLock.lock())
+        {
+            assert lock != null; // ignored on runtime
+            getCondition().setState(status);
+            lastActivity = Instant.now();
+        }
+    }
+
+    /** @return activity-status condition */
+    @Override
+    public T getStatus()
+    {
+        return getCondition().getState();
+	}
+
+    /**
+     *	Start activity.
+     *
+     *  @return AutoCloseable object for try-with-resources functionality
+     */
+    public CloseableActivity startActivity()
+    {
+        try (AutoCloseableLock lock = activityLock.lock())
+        {
+            assert lock != null; // ignored on runtime
+            if (isActive())
+            {
+                throw new ActivityRuntimeException("already active");
+            }
+            //- setup timestamps
+            startOfActivity = Instant.now();
+            lastActivity = startOfActivity;
+            endOfActivity = Instant.MAX; // unknown end-of-activity
+            return this::close;
+        }
+    }
+
+    /** Update last-activity timestamp */
+    @Override
+    public Instant touch()
+    {
+        try (AutoCloseableLock lock = activityLock.lock())
+        {
+            assert lock != null; // ignored on runtime
+            if (!isActive())
+            {
+                throw new ActivityRuntimeException("not active");
+            }
+            lastActivity = Instant.now();
+            return lastActivity;
+        }
+    }
+
+    /**
+     *	Close this activity
+     */
+    @Override
+    public void close()
+    {
+        try (AutoCloseableLock autoCloseableLock = activityLock.lock())
+        {
+            assert autoCloseableLock != null; // ignored on runtime
+            if (!isActive())
+            {
+                throw new ActivityRuntimeException("not active");
+            }
+            lastActivity = Instant.now();
+            endOfActivity = lastActivity;   // set end-of-activity (= last activity)
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        try (AutoCloseableLock lock = activityLock.lock())
+        {
+            assert lock != null; // ignored on runtime
+            return " startOfActivity=" + (startOfActivity==Instant.EPOCH? "": startOfActivity.toString())
+            	 + " lastActivity="    + lastActivity
+            	 + " endOfActivity="   + (endOfActivity==Instant.MAX? "": endOfActivity.toString())
+            	 + " status="          + condition;
+        }
+    }
+}

--- a/src/main/java/com/csitte/activity/ActivityRuntimeException.java
+++ b/src/main/java/com/csitte/activity/ActivityRuntimeException.java
@@ -1,23 +1,30 @@
 package com.csitte.activity;
 
+/** Runtime Exception for Activity Exceptions */
 public class ActivityRuntimeException extends RuntimeException
 {
+    private static final long serialVersionUID = -8376644119766382385L;
+
+    /** Constructor */
     public ActivityRuntimeException()
     {
         super();
     }
 
-    public ActivityRuntimeException(Throwable throwable)
+    /** Constructor */
+    public ActivityRuntimeException(final Throwable throwable)
     {
         super(throwable);
     }
 
-    public ActivityRuntimeException(String message, Throwable throwable)
+    /** Constructor */
+    public ActivityRuntimeException(final String message, final Throwable throwable)
     {
         super(message, throwable);
     }
 
-    public ActivityRuntimeException(String message)
+    /** Constructor */
+    public ActivityRuntimeException(final String message)
     {
         super(message);
     }

--- a/src/main/java/com/csitte/activity/CloseableActivity.java
+++ b/src/main/java/com/csitte/activity/CloseableActivity.java
@@ -2,6 +2,7 @@ package com.csitte.activity;
 
 import java.io.Closeable;
 
+/** Closeable Activity */
 public interface CloseableActivity extends Closeable
 {
     @Override

--- a/src/main/java/com/csitte/autocloseablelock/AutoCloseableLock.java
+++ b/src/main/java/com/csitte/autocloseablelock/AutoCloseableLock.java
@@ -1,9 +1,27 @@
 package com.csitte.autocloseablelock;
 
+/**
+ * The AutoCloseableLock interface provides an automatic lock release mechanism
+ * when used in try-with-resources statement.
+ *
+ * This interface is intended to be used in conjunction with the CloseableLock class.
+ *
+ * Usage example:
+ * try (AutoCloseableLock lock = closeableLock.lock()) {
+ *      // protected code
+ * }
+ *
+ */
+@SuppressWarnings("PMD.CommentSize")
 public interface AutoCloseableLock extends AutoCloseable
 {
     /**
+     * Overrides the close method of the AutoCloseable interface,
+     * providing an automatic lock release when the try-with-resources block is exited.
+     *
      * Unlocking doesn't throw any checked exception.
+     *
+     * @see AutoCloseable#close()
      */
     @Override
     void close();

--- a/src/main/java/com/csitte/autocloseablelock/AutoCloseableWriteLock.java
+++ b/src/main/java/com/csitte/autocloseablelock/AutoCloseableWriteLock.java
@@ -9,32 +9,49 @@ import java.util.function.BooleanSupplier;
  *  while ensuring that no other thread is permitted to acquire the write lock
  *  while it is in the process of downgrading.
 */
+@SuppressWarnings("PMD.CommentSize")
 public interface AutoCloseableWriteLock extends AutoCloseableLock
 {
     /**
-     *  Wait for timeout.
+     *  Waits for the specified period while holding the write lock.
      *
-     *  @param  timeout     null or 0 means: no timeout
+     *  <p>The {@code timeout} value must be greater than zero. Passing
+     *  {@code null} or a zero {@link Duration} results in a
+     *  {@link LockException}.</p>
+     *
+     *  @param timeout  the amount of time to wait
      */
     void wait(Duration timeout);
 
     /**
-     *  Wait for condition to become true or timeout.
+     *  Allows a thread to wait for a specified condition to be met, with a specified timeout.
      *
-     *  @param  fCondition  Represents a supplier of {@code boolean}-valued condition results
-     *  @param  timeout     null or 0 means: no timeout
+     *  @param  fCondition  Represents a supplier of {@code boolean}-valued condition results.
+     *                      It is important to ensure that the BooleanSupplier is efficient to avoid performance issues.
+     *  @param  timeout     {@code null} or {@link Duration#isZero() zero} means to wait without timeout
      *
-     *  @return true == condition met; false == timeout or interrupt occured
+     *  @return true == condition met; false == timeout or interrupt occurred
      */
     boolean waitForCondition(BooleanSupplier fCondition, Duration timeout);
 
     /**
-     *  Wakes up thread(s) which are waiting for the condition.
+     *  Allows a thread to wake up all waiting threads waiting on the lock.
      */
     void signalAll();
+
+    /**
+     *  Allows a thread to signal another thread waiting on the lock.
+     *  If any threads are waiting on this condition then one is selected for waking up.
+     */
     void signal();
 
+    /**
+     *  Downgrade write-lock to read-lock
+     */
     void downgradeToReadLock();
 
+    /**
+     *  Downgrade write-lock to read-lock (interruptibly)
+     */
     void downgradeToReadLockInterruptibly();
 }

--- a/src/main/java/com/csitte/autocloseablelock/AutoCloseableWriteLockImpl.java
+++ b/src/main/java/com/csitte/autocloseablelock/AutoCloseableWriteLockImpl.java
@@ -5,18 +5,35 @@ import java.util.function.BooleanSupplier;
 
 
 /**
- *  The thread that holds the write lock can downgrade to a read lock.
- *  It can acquire a read lock before it releases the write lock to downgrade from a write lock to a read lock
- *  while ensuring that no other thread is permitted to acquire the write lock
- *  while it is in the process of downgrading.
-*/
+ * The AutoCloseableWriteLockImpl class provides a wrapper for a CloseableReadWriteLock object,
+ * allowing the thread that holds the write lock to downgrade to a read lock.
+ *
+ * This is done by acquiring a read lock before releasing the write lock,
+ * ensuring that no other thread can acquire the write lock while the thread is
+ * in the process of downgrading.
+ *
+ * It is important to note that the methods waitForCondition, signalAll, and
+ * signal are only usable with write-lock.
+ * If they are called with a read-lock, it will throw a LockException of
+ * 'invalid state'.
+ *
+ * Also the methods downgradeToReadLock and downgradeToReadLockInterruptibly
+ * should only be called after the thread has acquired a write lock.
+ * If they are called before a write lock is acquired, it will throw a
+ * LockException of 'invalid state'
+ */
+@SuppressWarnings("PMD.CommentSize")
 public class AutoCloseableWriteLockImpl implements AutoCloseableWriteLock
 {
-    private CloseableReadWriteLock readWriteLock;
+    /** Read-Write-Lock used */
+    private final CloseableReadWriteLock readWriteLock;
 
-    private AutoCloseableLock autoCloseableReadLock;
-    private AutoCloseableLock autoCloseableWriteLock;
+    /** AutoCloseableLock for read-lock */
+    private AutoCloseableLock autoReadLock = NullAutoCloseableLock.INSTANCE;
+    /** AutoCloseableLock for write-lock */
+    private AutoCloseableLock autoWriteLock = NullAutoCloseableLock.INSTANCE;
 
+    /** default error text for invalid state errors */
     private static final String TXT_INVALID_STATE = "invalid state";
 
 
@@ -25,45 +42,54 @@ public class AutoCloseableWriteLockImpl implements AutoCloseableWriteLock
      *
      *  @param  readWriteLock   use this ReadWriteLock as basis
      */
-    public AutoCloseableWriteLockImpl(CloseableReadWriteLock readWriteLock)
+    public AutoCloseableWriteLockImpl(final CloseableReadWriteLock readWriteLock)
     {
         this.readWriteLock = readWriteLock;
     }
 
-    void writeLock()
+    /**
+     * Obtain an exclusive write lock on the associated readWriteLock instance.
+     */
+    protected void writeLock()
     {
-        if (autoCloseableWriteLock != null || autoCloseableReadLock != null)
+        if (autoWriteLock != NullAutoCloseableLock.INSTANCE || autoReadLock != NullAutoCloseableLock.INSTANCE)
         {
             throw new LockException(TXT_INVALID_STATE);
         }
-        autoCloseableWriteLock = readWriteLock.getWriteLock().lock();
+        autoWriteLock = readWriteLock.lockWriteLock();
     }
 
-    void writeLockInterruptibly()
+    /**
+     *  Lock write-lock (interruptibly)
+     */
+    protected void writeLockInterruptibly()
     {
-        if (autoCloseableWriteLock != null || autoCloseableReadLock != null)
+        if (autoWriteLock != NullAutoCloseableLock.INSTANCE || autoReadLock != NullAutoCloseableLock.INSTANCE)
         {
             throw new LockException(TXT_INVALID_STATE);
         }
-        autoCloseableWriteLock = readWriteLock.getWriteLock().lockInterruptibly();
+        autoWriteLock = readWriteLock.lockWriteLockInterruptibly();
     }
 
-    void tryWriteLock(Duration timeout)
+    /**
+     *  Try write-lock (with timeout)
+     */
+    protected void tryWriteLock(final Duration timeout)
     {
-        if (autoCloseableWriteLock != null || autoCloseableReadLock != null)
+        if (autoWriteLock != NullAutoCloseableLock.INSTANCE || autoReadLock != NullAutoCloseableLock.INSTANCE)
         {
             throw new LockException(TXT_INVALID_STATE);
         }
-        autoCloseableWriteLock = readWriteLock.getWriteLock().tryLock(timeout);
+        autoWriteLock = readWriteLock.tryLockWriteLock(timeout);
     }
 
     /**
      *  Wait for timeout.
      */
     @Override
-    public void wait(Duration timeout)
+    public void wait(final Duration timeout)
     {
-        if (autoCloseableWriteLock == null)
+        if (autoWriteLock == NullAutoCloseableLock.INSTANCE)
         {
             throw new LockException(TXT_INVALID_STATE);
         }
@@ -71,75 +97,75 @@ public class AutoCloseableWriteLockImpl implements AutoCloseableWriteLock
         {
             throw new LockException("invalid timeout value: " + timeout);
         }
-        readWriteLock.getWriteLock().waitForCondition(()->false, timeout);
+        readWriteLock.waitForWriteLockCondition(()->false, timeout);
     }
 
     @Override
     public void downgradeToReadLock()
     {
-        if (autoCloseableWriteLock == null)
+        if (autoWriteLock == NullAutoCloseableLock.INSTANCE)
         {
             throw new LockException(TXT_INVALID_STATE);
         }
-        autoCloseableReadLock = readWriteLock.getReadLock().lock();
-        autoCloseableWriteLock.close();
-        autoCloseableWriteLock = null;
+        autoReadLock = readWriteLock.readLock();
+        autoWriteLock.close();
+        autoWriteLock = NullAutoCloseableLock.INSTANCE;
     }
 
     @Override
     public void downgradeToReadLockInterruptibly()
     {
-        if (autoCloseableWriteLock == null)
+        if (autoWriteLock == NullAutoCloseableLock.INSTANCE)
         {
             throw new LockException(TXT_INVALID_STATE);
         }
-        autoCloseableReadLock = readWriteLock.getReadLock().lockInterruptibly();
-        autoCloseableWriteLock.close();
-        autoCloseableWriteLock = null;
+        autoReadLock = readWriteLock.readLockInterruptibly();
+        autoWriteLock.close();
+        autoWriteLock = NullAutoCloseableLock.INSTANCE;
     }
 
     @Override
-    public boolean waitForCondition(BooleanSupplier fCondition, Duration timeout)
+    public boolean waitForCondition(final BooleanSupplier fCondition, final Duration timeout)
     {
-        if (autoCloseableWriteLock == null) // only usable with write-lock
+        if (autoWriteLock == NullAutoCloseableLock.INSTANCE) // only usable with write-lock
         {
             throw new LockException(TXT_INVALID_STATE);
         }
-        return readWriteLock.getWriteLock().waitForCondition(fCondition, timeout);
+        return readWriteLock.waitForWriteLockCondition(fCondition, timeout);
     }
 
     @Override
     public void signalAll()
     {
-        if (autoCloseableWriteLock == null) // only usable with write-lock
+        if (autoWriteLock == NullAutoCloseableLock.INSTANCE) // only usable with write-lock
         {
             throw new LockException(TXT_INVALID_STATE);
         }
-        readWriteLock.getWriteLock().signalAll();
+        readWriteLock.signalAllWriteLock();
     }
 
     @Override
     public void signal()
     {
-        if (autoCloseableWriteLock == null) // only usable with write-lock
+        if (autoWriteLock == NullAutoCloseableLock.INSTANCE) // only usable with write-lock
         {
             throw new LockException(TXT_INVALID_STATE);
         }
-        readWriteLock.getWriteLock().signal();
+        readWriteLock.signalWriteLock();
     }
 
     @Override
     public void close()
     {
-        if (autoCloseableWriteLock != null)
+        if (autoWriteLock != NullAutoCloseableLock.INSTANCE)
         {
-            autoCloseableWriteLock.close();
-            autoCloseableWriteLock = null;
+            autoWriteLock.close();
+            autoWriteLock = NullAutoCloseableLock.INSTANCE;
         }
-        else if (autoCloseableReadLock != null)
+        if (autoReadLock != NullAutoCloseableLock.INSTANCE)
         {
-            autoCloseableReadLock.close();
-            autoCloseableReadLock = null;
+            autoReadLock.close();
+            autoReadLock = NullAutoCloseableLock.INSTANCE;
         }
     }
 }

--- a/src/main/java/com/csitte/autocloseablelock/CloseableReadWriteLock.java
+++ b/src/main/java/com/csitte/autocloseablelock/CloseableReadWriteLock.java
@@ -4,17 +4,21 @@ import java.time.Duration;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BooleanSupplier;
 
 
 /**
  *  Handles {@link ReadWriteLock}-type locks
  *
- * @author sit
+ *  @author sit
  */
+@SuppressWarnings({"PMD.CommentSize", "PMD.TooManyMethods"})
 public class CloseableReadWriteLock
 {
-    private final CloseableLock readLock;
-    private final CloseableLock writeLock;
+    /** used to lock read-lock */
+    private final CloseableLock closeReadLock;
+    /** used to lock write-lock */
+    private final CloseableLock closeWriteLock;
 
     /**
      *  Default Constructor.
@@ -31,10 +35,10 @@ public class CloseableReadWriteLock
      *
      *  @param  readWriteLock   use this {@link ReadWriteLock} as underlying lock
      */
-    public CloseableReadWriteLock(ReadWriteLock readWriteLock)
+    public CloseableReadWriteLock(final ReadWriteLock readWriteLock)
     {
-        this.readLock  = new CloseableLock(readWriteLock.readLock());
-        this.writeLock = new CloseableLock(readWriteLock.writeLock());
+        this.closeReadLock  = new CloseableLock(readWriteLock.readLock());
+        this.closeWriteLock = new CloseableLock(readWriteLock.writeLock());
     }
 
     /**
@@ -42,7 +46,7 @@ public class CloseableReadWriteLock
      */
     public CloseableLock getReadLock()
     {
-        return readLock;
+        return closeReadLock;
     }
 
     /**
@@ -50,7 +54,19 @@ public class CloseableReadWriteLock
      */
     public CloseableLock getWriteLock()
     {
-        return writeLock;
+        return closeWriteLock;
+    }
+
+    /** direct write-lock lock */
+    protected AutoCloseableLock lockWriteLock()
+    {
+        return closeWriteLock.lock();
+    }
+
+    /** direct write-lock lock (interruptibly) */
+    protected AutoCloseableLock lockWriteLockInterruptibly()
+    {
+        return closeWriteLock.lockInterruptibly();
     }
 
     /**
@@ -58,7 +74,15 @@ public class CloseableReadWriteLock
      */
     public AutoCloseableLock readLock()
     {
-        return readLock.lock();
+        return closeReadLock.lock();
+    }
+
+    /**
+     * @return an {@link AutoCloseableLock} once the read-lock has been acquired (interruptibly)
+     */
+    public AutoCloseableLock readLockInterruptibly()
+    {
+        return closeReadLock.lockInterruptibly();
     }
 
     /**
@@ -68,7 +92,7 @@ public class CloseableReadWriteLock
      */
     public AutoCloseableWriteLock writeLock()
     {
-        AutoCloseableWriteLockImpl lock = new AutoCloseableWriteLockImpl(this);
+        final AutoCloseableWriteLockImpl lock = new AutoCloseableWriteLockImpl(this);
         lock.writeLock();
         return lock;
     }
@@ -80,7 +104,7 @@ public class CloseableReadWriteLock
      */
     public AutoCloseableWriteLock writeLockInterruptibly()
     {
-        AutoCloseableWriteLockImpl lock = new AutoCloseableWriteLockImpl(this);
+        final AutoCloseableWriteLockImpl lock = new AutoCloseableWriteLockImpl(this);
         lock.writeLockInterruptibly();
         return lock;
     }
@@ -90,20 +114,44 @@ public class CloseableReadWriteLock
      *
      *  @return an {@link AutoCloseableLock} once the read-lock has been acquired.
      */
-    public AutoCloseableLock tryReadLock(Duration timeout)
+    public AutoCloseableLock tryReadLock(final Duration timeout)
     {
-        return readLock.tryLock(timeout);
+        return closeReadLock.tryLock(timeout);
     }
 
+    /** try write-lock (with timeout) */
+    protected AutoCloseableLock tryLockWriteLock(final Duration timeout)
+    {
+        return closeWriteLock.tryLock(timeout);
+    }
     /**
      *  @param timeout  0==return immediately or throw LockException if locked
      *
      *  @return an {@link AutoCloseableWriteLock} once the write-lock has been acquired.
      */
-    public AutoCloseableWriteLock tryWriteLock(Duration timeout)
+    public AutoCloseableWriteLock tryWriteLock(final Duration timeout)
     {
-        AutoCloseableWriteLockImpl lock = new AutoCloseableWriteLockImpl(this);
+        final AutoCloseableWriteLockImpl lock = new AutoCloseableWriteLockImpl(this);
         lock.tryWriteLock(timeout);
         return lock;
     }
+
+    /** Wait for write-lock condition (with timeout) */
+    protected boolean waitForWriteLockCondition(final BooleanSupplier fCondition, final Duration timeout)
+    {
+        return closeWriteLock.waitForCondition(fCondition, timeout);
+    }
+
+    /** Signal all write-lock clients */
+    protected void signalAllWriteLock()
+    {
+        closeWriteLock.signalAll();
+    }
+
+    /** Signal one of the write-lock clients */
+    protected void signalWriteLock()
+    {
+        closeWriteLock.signal();
+    }
+
 }

--- a/src/main/java/com/csitte/autocloseablelock/LockCondition.java
+++ b/src/main/java/com/csitte/autocloseablelock/LockCondition.java
@@ -1,22 +1,38 @@
 package com.csitte.autocloseablelock;
 
 
+/**
+ * The LockCondition class provides a way to associate a state with a lock,
+ * allowing threads to wait for a certain condition to be met before proceeding.
+ *
+ * Usage example:
+ *  {@code
+ *  LockCondition<String> lockCondition =
+ *      new LockCondition<>(closeableLock, "initial state");
+ *  lockCondition.setState("new state");
+ *  }
+ *
+ * @param <T> the type of the state associated with the lock
+ */
+@SuppressWarnings("PMD.CommentSize")
 public class LockCondition<T>
 {
+    /** State of condition */
     private T state;
 
+    /** Lock for condition */
     private final CloseableLock lock;
 
     /**
      *  Constructor
      *
      *  @param lock         the associated lock
-     *  @param initalState  the initial state of this condition
+     *  @param initialState the initial state of this condition
      */
-    public LockCondition(CloseableLock lock, T initalState)
+    public LockCondition(final CloseableLock lock, final T initialState)
     {
         this.lock = lock;
-        this.state = initalState;
+        this.state = initialState;
         lock.getOrCreateCondition();
     }
 
@@ -27,10 +43,11 @@ public class LockCondition<T>
      *
      *  @param state    new state
      */
-    public void setState(T state)
+    public void setState(final T state)
     {
         try (AutoCloseableLock autoCloseableLock = lock.lock())
         {
+            assert autoCloseableLock != null; // ignored on runtime
             this.state = state;
             lock.signalAll();
         }
@@ -43,6 +60,7 @@ public class LockCondition<T>
     {
         try (AutoCloseableLock autoCloseableLock = lock.lock())
         {
+            assert autoCloseableLock != null; // ignored on runtime
             return state;
         }
     }
@@ -52,11 +70,12 @@ public class LockCondition<T>
      */
     public static class BooleanLockCondition extends LockCondition<Boolean>
     {
-        public BooleanLockCondition(CloseableLock lock)
+        /** Constructor */
+        public BooleanLockCondition(final CloseableLock lock)
         {
             super(lock, false);
         }
-
+        /** @return state is true */
         public boolean isTrue()
         {
             return Boolean.TRUE.equals(getState());

--- a/src/main/java/com/csitte/autocloseablelock/LockException.java
+++ b/src/main/java/com/csitte/autocloseablelock/LockException.java
@@ -1,27 +1,31 @@
 package com.csitte.autocloseablelock;
 
+/** Lock Runtime Exception */
 public class LockException extends RuntimeException
 {
     private static final long serialVersionUID = 1;
 
+    /** Constructor */
     public LockException()
     {
-        // empty constructor
+        super();
     }
 
-    public LockException(String msg)
+    /** Constructor */
+    public LockException(final String msg)
     {
         super(msg);
     }
 
-    public LockException(Throwable throwable)
+    /** Constructor */
+    public LockException(final Throwable throwable)
     {
         super(throwable);
     }
 
-    public LockException(String message, Throwable throwable)
+    /** Constructor */
+    public LockException(final String message, final Throwable throwable)
     {
         super(message, throwable);
     }
-
 }

--- a/src/main/java/com/csitte/autocloseablelock/LockTimeoutException.java
+++ b/src/main/java/com/csitte/autocloseablelock/LockTimeoutException.java
@@ -2,10 +2,12 @@ package com.csitte.autocloseablelock;
 
 import java.time.Duration;
 
+/** Runtime Exception for lock-timeout */
 public class LockTimeoutException extends LockException
 {
     private static final long serialVersionUID = 1;
 
+    /** Elapsed time till timeout */
     private final Duration elapsedTime;
 
 
@@ -15,7 +17,7 @@ public class LockTimeoutException extends LockException
      *	@param	name			name of lock
      *	@param	elapsedTime		elapsed time waiting for a lock
      */
-    public LockTimeoutException(String name, Duration elapsedTime)
+    public LockTimeoutException(final String name, final Duration elapsedTime)
     {
         super(name + " - timeout after " + elapsedTime);
         this.elapsedTime = elapsedTime;
@@ -26,12 +28,13 @@ public class LockTimeoutException extends LockException
      *
      *	@param	elapsedTime		elapsed time waiting for a lock
      */
-    public LockTimeoutException(Duration elapsedTime)
+    public LockTimeoutException(final Duration elapsedTime)
     {
         super("timeout after " + elapsedTime);
         this.elapsedTime = elapsedTime;
     }
 
+    /** return elapsed time before timeout */
     public Duration getElapsedTime()
     {
         return elapsedTime;

--- a/src/main/java/com/csitte/autocloseablelock/NullAutoCloseableLock.java
+++ b/src/main/java/com/csitte/autocloseablelock/NullAutoCloseableLock.java
@@ -1,0 +1,21 @@
+package com.csitte.autocloseablelock;
+
+/** Null-Object pattern class */
+public final class NullAutoCloseableLock implements AutoCloseableLock
+{
+    /** Singleton */
+    public static final NullAutoCloseableLock INSTANCE = new NullAutoCloseableLock();
+
+    /** Constructor */
+    private NullAutoCloseableLock()
+    {
+        // do nothing
+    }
+
+    /** @see java.lang.AutoCloseable */
+    @Override
+    public void close()
+    {
+        // do nothing
+    }
+}

--- a/src/test/java/test/com/csitte/activity/ActivityTest.java
+++ b/src/test/java/test/com/csitte/activity/ActivityTest.java
@@ -17,16 +17,17 @@ import org.junit.jupiter.api.Test;
 import com.csitte.activity.ActivityRuntimeException;
 import com.csitte.activity.CloseableActivity;
 
-public class ActivityTest
+@SuppressWarnings("PMD")
+class ActivityTest
 {
     private static final Logger LOG = LogManager.getLogger(ActivityTest.class);
 
 	@Test
-	public void test()
+	void test()
 	{
 	    LOG.debug("new TestActivity()");
-		DummyActivity activity = new DummyActivity();
-		assertFalse(activity.isActive());
+		final DummyActivity activity = DummyActivity.createInstance();
+		assertFalse(activity.isActive(), "is active");
 		assertNull(activity.getStartOfActivity());
 		assertNotNull(activity.getLastActivity());
 		assertNull(activity.getEndOfActivity());
@@ -35,12 +36,13 @@ public class ActivityTest
 		activity.setShutdownRequest(false); // only for junit test
 
 	    LOG.debug("start of test-activity");
-		try (CloseableActivity ca = activity.startActivity())
+		try (CloseableActivity closeableActivity = activity.startActivity())
 		{
+		    assert closeableActivity != null;
 			assertTrue(activity.isActive());
 			assertNull(activity.getEndOfActivity());
 
-			assertThrows(ActivityRuntimeException.class, () -> activity.startActivity());
+			assertThrows(ActivityRuntimeException.class, activity::startActivity);
 
 			activity.updateStatus("activity in progress");
 			assertEquals("activity in progress", activity.getStatus());
@@ -49,12 +51,12 @@ public class ActivityTest
 			activity.startActivityThread();
 
 		    LOG.debug("Wait until activity is running");
-			assertTrue(activity.getLock().waitForCondition(() -> activity.isThreadRunning(), null));
+			assertTrue(activity.getLock().waitForCondition(activity::isThreadRunning, null));
 
 		    LOG.debug("Wait 1 1/2 second");
 			activity.getLock().waitForCondition(() -> false, Duration.ofMillis(1500));
 
-            Instant instant = activity.touch();
+            final Instant instant = activity.touch();
 
 		    LOG.debug("Request shutdown");
 			activity.setShutdownRequest(true);
@@ -68,8 +70,32 @@ public class ActivityTest
 		}
 	    LOG.debug("end of activity");
 		assertFalse(activity.isActive());
-		assertThrows(ActivityRuntimeException.class, () -> activity.close());
-        assertThrows(ActivityRuntimeException.class, () -> activity.touch());
-        LOG.debug(activity.toString());
+		assertThrows(ActivityRuntimeException.class, activity::close);
+        assertThrows(ActivityRuntimeException.class, activity::touch);
+        LOG.debug(activity::toString);
 	}
+
+    @Test
+    public void testToString()
+    {
+        DummyActivity activity = DummyActivity.createInstance();
+        String initial = activity.toString();
+        assertTrue(initial.contains("startOfActivity= "));
+        assertTrue(initial.contains("lastActivity=1970-01-01T00:00:00Z"));
+        assertTrue(initial.contains("endOfActivity= "));
+        assertTrue(initial.endsWith("status=null"));
+
+        try (CloseableActivity ignored = activity.startActivity())
+        {
+            String running = activity.toString();
+            assertFalse(running.contains("startOfActivity= "));
+            assertTrue(running.contains("endOfActivity= "));
+            assertTrue(running.contains("status=null"));
+        }
+
+        String finished = activity.toString();
+        assertFalse(finished.contains("startOfActivity= "));
+        assertFalse(finished.contains("endOfActivity= "));
+        assertTrue(finished.contains("status=null"));
+    }
 }

--- a/src/test/java/test/com/csitte/autocloseablelock/AutoCloseableWriteLockImplTest.java
+++ b/src/test/java/test/com/csitte/autocloseablelock/AutoCloseableWriteLockImplTest.java
@@ -1,0 +1,164 @@
+package test.com.csitte.autocloseablelock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.junit.jupiter.api.Test;
+
+import com.csitte.autocloseablelock.AutoCloseableWriteLock;
+import com.csitte.autocloseablelock.AutoCloseableWriteLockImpl;
+import com.csitte.autocloseablelock.CloseableReadWriteLock;
+import com.csitte.autocloseablelock.LockException;
+
+@SuppressWarnings("PMD")
+public class AutoCloseableWriteLockImplTest
+{
+
+    @Test
+    public void testWriteLock()
+    {
+        CloseableReadWriteLock readWriteLock = new CloseableReadWriteLock(new ReentrantReadWriteLock());
+        AutoCloseableWriteLockImplWrapper lock = new AutoCloseableWriteLockImplWrapper(readWriteLock);
+        LockException exception;
+
+        // Test write-lock and unlock
+        lock.writeLock();
+        lock.close();
+
+        // Test LockException
+        lock.writeLock();
+        exception = assertThrows(LockException.class, lock::writeLock);
+        assertEquals("invalid state", exception.getMessage());
+        lock.close();
+
+        // Test write-lock and downgrade to read-lock
+        lock.writeLock();
+        lock.downgradeToReadLock();
+        lock.close();
+
+        lock.writeLock();
+        lock.downgradeToReadLock();
+        exception = assertThrows(LockException.class, lock::writeLock);
+        assertEquals("invalid state", exception.getMessage());
+        lock.close();
+
+        lock.writeLock();
+        lock.downgradeToReadLock();
+        exception = assertThrows(LockException.class, lock::downgradeToReadLock);
+        assertEquals("invalid state", exception.getMessage());
+        lock.close();
+
+        // call extra close (does nothing)
+        lock.close();
+    }
+
+    @Test
+    public void testWriteLockInterruptibly() throws InterruptedException
+    {
+        CloseableReadWriteLock readWriteLock = new CloseableReadWriteLock(new ReentrantReadWriteLock());
+
+        AutoCloseableWriteLock acwl = readWriteLock.writeLockInterruptibly();
+        RunnableObject runnable = new RunnableObject(readWriteLock);
+        Thread thread1 = new Thread(runnable);
+        thread1.start(); // thread is also trying to acquire the write-lock.
+        TimeUnit.MILLISECONDS.sleep(100);
+        thread1.interrupt();
+        thread1.join();
+        assertNotNull(runnable.getException());
+        assertTrue(runnable.getException() instanceof LockException);
+        acwl.close();
+
+        //-
+        LockException exception;
+        AutoCloseableWriteLockImplWrapper lock = new AutoCloseableWriteLockImplWrapper(readWriteLock);
+        lock.writeLockInterruptibly();
+        exception = assertThrows(LockException.class, lock::writeLockInterruptibly);
+        assertEquals("invalid state", exception.getMessage());
+        lock.downgradeToReadLockInterruptibly();
+        exception = assertThrows(LockException.class, lock::writeLockInterruptibly);
+        assertEquals("invalid state", exception.getMessage());
+        lock.close();
+
+        //-
+        exception = assertThrows(LockException.class, lock::downgradeToReadLockInterruptibly);
+        assertEquals("invalid state", exception.getMessage());
+    }
+
+    @Test
+    public void testTryWriteLock() throws InterruptedException
+    {
+        LockException exception;
+        CloseableReadWriteLock readWriteLock = new CloseableReadWriteLock(new ReentrantReadWriteLock());
+
+        //-
+        AutoCloseableWriteLockImplWrapper lock = new AutoCloseableWriteLockImplWrapper(readWriteLock);
+        lock.tryWriteLock(null);
+        exception = assertThrows(LockException.class, lock::writeLockInterruptibly);
+        assertEquals("invalid state", exception.getMessage());
+        lock.downgradeToReadLockInterruptibly();
+        exception = assertThrows(LockException.class, lock::writeLockInterruptibly);
+        assertEquals("invalid state", exception.getMessage());
+        lock.close();
+
+        //-
+        exception = assertThrows(LockException.class, lock::downgradeToReadLockInterruptibly);
+        assertEquals("invalid state", exception.getMessage());
+    }
+
+    public static class AutoCloseableWriteLockImplWrapper extends AutoCloseableWriteLockImpl
+    {
+        public AutoCloseableWriteLockImplWrapper(CloseableReadWriteLock readWriteLock)
+        {
+            super(readWriteLock);
+        }
+        @Override
+        public void writeLock()
+        {
+            super.writeLock();
+        }
+        @Override
+        public void writeLockInterruptibly()
+        {
+            super.writeLockInterruptibly();
+        }
+        @Override
+        public void tryWriteLock(Duration timeout)
+        {
+            super.tryWriteLock(timeout);
+        }
+    }
+
+    public static class RunnableObject implements Runnable
+    {
+        private CloseableReadWriteLock lock;
+        private Exception exception;
+
+        public RunnableObject(CloseableReadWriteLock lock)
+        {
+            this.lock = lock;
+        }
+        @Override
+        public void run()
+        {
+            try
+            {
+                lock.writeLockInterruptibly();
+            }
+            catch (RuntimeException x)
+            {
+                exception = x;
+            }
+        }
+        public Exception getException()
+        {
+            return exception;
+        }
+    }
+
+}

--- a/src/test/java/test/com/csitte/autocloseablelock/LockConditionTest.java
+++ b/src/test/java/test/com/csitte/autocloseablelock/LockConditionTest.java
@@ -13,6 +13,7 @@ import com.csitte.autocloseablelock.AutoCloseableLock;
 import com.csitte.autocloseablelock.CloseableLock;
 import com.csitte.autocloseablelock.LockCondition;
 
+@SuppressWarnings("PMD")
 public class LockConditionTest
 {
     private static final Logger LOG = LogManager.getLogger(LockConditionTest.class);


### PR DESCRIPTION
## Summary
- fix generic example formatting in `LockCondition` Javadoc

## Testing
- `javadoc -d target/javadoc @/tmp/sources.txt`
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_685559eaa9448325b154447d378db734